### PR TITLE
Add Breez logo next to Vinteum in Global Partners

### DIFF
--- a/components/partners.tsx
+++ b/components/partners.tsx
@@ -8,7 +8,7 @@ function Partners() {
         <Badge variant="outline" className="mb-4 bg-pink-700">
           Global Partners
         </Badge>
-        <div className="flex justify-center mt-8">
+        <div className="mt-8 flex flex-col items-center justify-center gap-8 md:flex-row md:gap-12">
           <Link
             href="https://vinteum.org"
             target="_blank"
@@ -17,6 +17,18 @@ function Partners() {
             <img
               src="/partners/vinteum.png"
               alt="Vinteum"
+              className="h-12 md:h-16 w-auto hover:opacity-80 transition-opacity"
+            />
+          </Link>
+
+          <Link
+            href="https://breez.technology"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <img
+              src="/partners/breez.svg"
+              alt="Breez"
               className="h-12 md:h-16 w-auto hover:opacity-80 transition-opacity"
             />
           </Link>

--- a/public/partners/breez.svg
+++ b/public/partners/breez.svg
@@ -1,0 +1,9 @@
+<svg width="800" height="220" viewBox="0 0 800 220" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g fill="#DCDCDC" stroke="#DCDCDC" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M70 35h65a55 55 0 0 1 0 110H70" stroke-width="24"/>
+    <path d="M70 35v110" stroke-width="24"/>
+    <path d="M55 58h40M40 88h55M40 118h55" stroke-width="18"/>
+    <path d="M165 90c0-25 20-45 45-45s45 20 45 45-20 45-45 45h-75" stroke-width="24"/>
+  </g>
+  <text x="250" y="150" font-family="Inter, Arial, sans-serif" font-size="140" font-weight="500" fill="#DCDCDC">reez</text>
+</svg>


### PR DESCRIPTION
### Motivation
- Add Breez to the Global Partners list so the Breez logo appears to the right of Vinteum on desktop and stacks on mobile (responsive side-by-side / stacked behavior).

### Description
- Update `components/partners.tsx` to use a responsive container (`flex flex-col ... md:flex-row`) and add a linked Breez logo image, and add the new asset `public/partners/breez.svg`.

### Testing
- Ran the site with `npm run dev` and captured Playwright screenshots for desktop and mobile to verify layout; `npm run lint` was blocked by Next.js interactive ESLint setup in this environment, and `npm run build` failed due to inability to fetch the Google Font `DM Mono` (network font fetch restriction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993b4226f8c8324ba27079b03d1b88e)